### PR TITLE
[SONAR] fix: address SonarQube quality issues

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -27,7 +27,7 @@ jobs:
     - run: npm run lint:ci --if-present
     - run: npm run test:coverage --if-present
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage/lcov.info

--- a/src/__tests/testExpressServer.ts
+++ b/src/__tests/testExpressServer.ts
@@ -8,6 +8,9 @@ import { createPaymentMiddleware } from '../index'
 // Create Express app instance
 export const app = express()
 
+// Disable x-powered-by header to prevent version disclosure
+app.disable('x-powered-by')
+
 // Middleware setup
 app.use(bodyParser.json())
 app.use(express.urlencoded({ extended: true }))
@@ -54,7 +57,8 @@ app.use(createPaymentMiddleware({
 }))
 
 app.get('/weather', async (req: Request, res: Response) => {
-  const response = await fetch('https://openweathermap.org/data/2.5/weather?id=5746545&appid=439d4b804bc8187953eb36d2a8c26a02', { method: 'GET' })
+  const appId = process.env.OPENWEATHER_APP_ID ?? 'test'
+  const response = await fetch(`https://openweathermap.org/data/2.5/weather?id=5746545&appid=${appId}`, { method: 'GET' })
   const weatherData = await response.json()
   res.json(weatherData)
 })
@@ -67,9 +71,9 @@ app.use((req, res, next) => {
     message: 'The requested resource was not found on this server.'
   })
 })
-const port = 3000
+const defaultPort = 3000
 // Export a function to start the server programmatically
-export const startServer = (port = 3000): ReturnType<typeof app.listen> => {
+export const startServer = (port = defaultPort): ReturnType<typeof app.listen> => {
   return app.listen(port, () => {
     console.log(`Server is running on http://localhost:${port}`)
   })


### PR DESCRIPTION
## Summary
- Pin `codecov/codecov-action` to full commit SHA `b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238` (v4.6.0) to address supply chain security hotspot (S7637)
- Disable Express `x-powered-by` header in test server to prevent version disclosure (S5689)
- Replace hardcoded OpenWeatherMap API key with environment variable `OPENWEATHER_APP_ID` (S2068)
- Fix variable shadowing for `port` constant in test server

## Before/After Metrics

| Metric | Before | After (Expected) |
|--------|--------|-------------------|
| Security Rating | C (3.0) | A (1.0) |
| Security Hotspots Reviewed | 0% (0/2) | 100% (2/2) |
| Vulnerabilities | 2 | 0 |
| Bugs | 0 | 0 |
| Code Smells | 4 | 3 or fewer |
| Duplicated Lines | 0% | 0% |
| Reliability Rating | A | A |
| Maintainability Rating | A | A |

## Test plan
- [x] `npx tsc --noEmit` passes (type check clean)
- [x] Test failure is pre-existing on master (beforeAll timeout in integration test - not caused by these changes)
- [ ] SonarQube quality gate passes after merge

## Notes
- Security hotspots could not be marked as REVIEWED via API (insufficient permissions) - will need manual review or will be resolved on next SonarQube scan after merge
- The integration test timeout failure exists on master and is unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)